### PR TITLE
Now Errorf(...) produces nil if get nil error

### DIFF
--- a/hierr.go
+++ b/hierr.go
@@ -53,8 +53,12 @@ type Error struct {
 //
 // Have same semantics as `fmt.Errorf()`.
 //
-// With nestedError == nil call will be equal to `fmt.Errorf()`.
+// With nestedError == nil method returns nil error.
 func Errorf(nestedError error, message string, args ...interface{}) error {
+	if nestedError == nil {
+		return nil
+	}
+
 	return Error{
 		Message: fmt.Sprintf(message, args...),
 		Nested:  nestedError,

--- a/hierr_test.go
+++ b/hierr_test.go
@@ -5,33 +5,23 @@ import "fmt"
 
 func ExampleError() {
 	testcases := []error{
-		Errorf(nil, ""),
 		Errorf(nil, "simple error"),
-		Errorf(nil, "integer: %d", 1),
 		Errorf(errors.New("nested"), "top level"),
 		Errorf(errors.New("nested"), "top level: %s", "formatting"),
-		Errorf(Errorf(errors.New("low level"), "nested"), "top level"),
+		Errorf(Errorf(errors.New("low level"), "nested"), "top level integer %d", 1),
 	}
 
 	for _, test := range testcases {
 		fmt.Println()
 		fmt.Println("{{{")
-		fmt.Println(test.Error())
+		fmt.Println(test)
 		fmt.Println("}}}")
 	}
 
 	// Output:
 	//
 	// {{{
-	//
-	// }}}
-	//
-	// {{{
-	// simple error
-	// }}}
-	//
-	// {{{
-	// integer: 1
+	// <nil>
 	// }}}
 	//
 	// {{{
@@ -45,7 +35,7 @@ func ExampleError() {
 	// }}}
 	//
 	// {{{
-	// top level
+	// top level integer 1
 	// └─ nested
 	//    └─ low level
 	// }}}


### PR DESCRIPTION
This is more useful than acting as `fmt.Errorf()` as now possible contructions like that:

```
func Method() error {
    return hierr.Errorf(someOtherFunction(), "description")
}
```

and no need to check if `someOtherFunction()` returns nil error.
